### PR TITLE
Arregla el crasheo cuando solo hay un movimiento para recordar.

### DIFF
--- a/LA BASE DE SKY/Data/Scripts/067_Scripts de la base/006_BetterMoveRelearner.rb
+++ b/LA BASE DE SKY/Data/Scripts/067_Scripts de la base/006_BetterMoveRelearner.rb
@@ -156,9 +156,9 @@ class UI::MoveReminderVisuals < UI::BaseVisuals
 
   def moves=(move_list)
     @moves = move_list
-    @index = @moves.length - 1 if @index >= @moves.length
+    @index = [@moves.length - 1, 0].max if @index >= @moves.length
     refresh_on_index_changed(@index)
-    @cursor.visible = false if @moves.empty?
+    @sprites[:cursor].visible = false if @moves.empty?
     refresh
   end
 
@@ -239,6 +239,7 @@ class UI::MoveReminderVisuals < UI::BaseVisuals
   end
 
   def draw_move_properties
+    return if @moves.empty?
     move = @moves[@index]
     move_data = GameData::Move.get(move[0])
     # Power


### PR DESCRIPTION
Arregla el crasheo cuando solo hay un movimiento para recordar en el pokemon, el bug proviene de betterMoveRelearner.

Para probar, en el pueblo inicial, hablar con el científico y que te de al Celebi:
<img width="326" height="293" alt="imagen" src="https://github.com/user-attachments/assets/22179b45-f093-4818-ad03-84381e441c48" />

Te vas a los datos del pokemon, a los movimientos, y a olvidar movimiento, uno cualquiera:
<img width="502" height="378" alt="imagen" src="https://github.com/user-attachments/assets/b7032579-0fdf-4db5-8a36-cde280a167dc" />

Luego le das a recordar movimientos, y cuando solo hay 1 disponible y lo aprendes, sin el fix crashea en ese momento y salta error:
<img width="505" height="380" alt="imagen" src="https://github.com/user-attachments/assets/bc1dfe3e-4044-47e7-ba61-f83710a35528" />

<img width="506" height="424" alt="imagen" src="https://github.com/user-attachments/assets/81c8255a-8486-412a-aaba-04d097165230" />

Con el fix, aparece bien el mensaje de que no hay mas movimientos para recordar y no crashea:
<img width="502" height="402" alt="imagen" src="https://github.com/user-attachments/assets/63403cd5-5aaa-40c1-a589-116f2e4c1926" />